### PR TITLE
Added dropCanvasData hook

### DIFF
--- a/scripts/hooks.mjs
+++ b/scripts/hooks.mjs
@@ -1,6 +1,17 @@
 import { flagScope, moduleId, soundTypes } from "./constants.mjs";
 
 /**
+ * A hook event that fires when some useful data is dropped onto the Canvas.
+ * @event dropCanvasData
+ * @category Canvas
+ * @param {import("../foundry/client/canvas/board.mjs").default} canvas The Canvas
+ * @param {object} data   The data that has been dropped onto the Canvas
+ */
+export function dropCanvasData(canvas, data) {
+  if (foundry.utils.getProperty(data, "data.flags.syrinscape-control.soundId")) return false;
+}
+
+/**
  * Add Syrinscape-specific inputs to the PlaylistSoundConfig app
  * @param {InstanceType<foundry["applications"]["sheets"]["PlaylistSoundConfig"]>} app
  * @param {HTMLElement} html

--- a/setup.mjs
+++ b/setup.mjs
@@ -94,6 +94,9 @@ Hooks.on("globalAmbientVolumeChanged", (volume) => {
   syrinscape.player.audioSystem.setLocalVolume(volume);
 });
 
+// Prevent creating ambient sounds from the Syrinscape Browser
+Hooks.on("dropCanvasData", hooks.dropCanvasData);
+
 /**
  * App Rendering Hooks
  */


### PR DESCRIPTION
Added a hook checking if there was a soundId associated with the data. This won't prevent browser => playlist => canvas, but that seems indirect enough I don't think we need to block it.

Closes #36 