### PR TITLE
[#20, #41] Allow for dragging onto the hotbar to create a macro. Fix injected elements not being draggable.

### DIFF
--- a/setup.mjs
+++ b/setup.mjs
@@ -101,6 +101,9 @@ Hooks.on("globalAmbientVolumeChanged", (volume) => {
 // Prevent creating ambient sounds from the Syrinscape Browser
 Hooks.on("dropCanvasData", hooks.dropCanvasData);
 
+// Create syrinscape macros on hotbar drops.
+Hooks.on("hotbarDrop", hooks.hotbarDrop);
+
 /**
  * App Rendering Hooks
  */


### PR DESCRIPTION
Closes #41.

Re #20: Dragging from the browser and onto the hotbar now creates a custom macro using the `utils` methods.