### PR TITLE
Adjusted rendering of additional playlist sound fields

### DIFF
--- a/scripts/hooks.mjs
+++ b/scripts/hooks.mjs
@@ -30,6 +30,7 @@ export function renderPlaylistSoundConfig(app, html, context, options) {
     name: flagScope + "soundType",
     value: sound.getFlag(moduleId, "soundType"),
     options: soundTypes,
+    classes: ["slim"],
     localize: true,
   });
 


### PR DESCRIPTION
The label for Syrinscape Sound Type was wrapping to two lines

<img width="474" height="183" alt="image" src="https://github.com/user-attachments/assets/ebbc76f8-c715-44d7-9cd7-356f973c6dfc" />
