### PR TITLE
Allow searching in string tags element

### DIFF
--- a/languages/en.json
+++ b/languages/en.json
@@ -64,6 +64,9 @@
         "pathfinder": "Pathfinder",
         "sci-fi": "Sci-Fi",
         "sfx": "SFX"
+      },
+      "ERRORS": {
+        "invalidValue": "The input value [{value}] is not in the list of available options."
       }
     },
     "SETTINGS": {

--- a/scripts/browser-filter-model.mjs
+++ b/scripts/browser-filter-model.mjs
@@ -22,11 +22,11 @@ export default class SyrinscapeFilterModel extends foundry.abstract.DataModel {
   /** @inheritdoc */
   static defineSchema() {
     return {
-      product: new SetField(new StringField()),
-      soundset: new SetField(new StringField()),
-      status: new SetField(new StringField()),
-      subcategory: new SetField(new StringField()),
-      subtype: new SetField(new StringField()),
+      product: new syrinscapeControl.data.fields.ListSetField(),
+      soundset: new syrinscapeControl.data.fields.ListSetField(),
+      status: new syrinscapeControl.data.fields.ListSetField(),
+      subcategory: new syrinscapeControl.data.fields.ListSetField(),
+      subtype: new syrinscapeControl.data.fields.ListSetField(),
     };
   }
 
@@ -122,6 +122,7 @@ export default class SyrinscapeFilterModel extends foundry.abstract.DataModel {
    * @type {Record<string, Set<string>>}
    */
   get cached() {
+    /** @type {Record<string, Set<string>>} */
     const data = {
       product: this.#product,
       soundset: this.#soundset,
@@ -131,6 +132,8 @@ export default class SyrinscapeFilterModel extends foundry.abstract.DataModel {
     };
 
     if (!this.#cached) {
+      // Clear out any existing caching.
+      for (const k in data) data[k].clear();
 
       // Populate caching.
       for (const entry of this.#application.collection) {

--- a/scripts/fields.mjs
+++ b/scripts/fields.mjs
@@ -1,0 +1,86 @@
+/**
+ * Subclass of `HTMLStringTagsElement` that allows for use of `datalist`.
+ */
+export class HTMLStringTagsListElement extends foundry.applications.elements.HTMLStringTagsElement {
+  /** @inheritdoc */
+  static tagName = "string-tags-list";
+
+  /* -------------------------------------------------- */
+
+  /**
+   * The data list options.
+   * @type {{value: string, label: string}[]}
+   */
+  #listOptions;
+
+  /* -------------------------------------------------- */
+
+  /**
+   * Unique id for datalist.
+   * @type {string}
+   */
+  #listId = foundry.utils.randomID();
+
+  /* -------------------------------------------------- */
+
+  /**
+   * The list element.
+   * @type {HTMLDataListElement}
+   */
+  #list;
+
+  /* -------------------------------------------------- */
+
+  /** @inheritdoc */
+  _buildElements() {
+    const [tags, input, button] = super._buildElements();
+    input.setAttribute("list", this.#listId);
+
+    this.#listOptions = JSON.parse(this.getAttribute("listOptions"));
+    this.removeAttribute("listOptions");
+
+    const list = this.#list = document.createElement("DATALIST");
+    list.setAttribute("id", this.#listId);
+    for (const { value, label } of this.#listOptions) {
+      list.insertAdjacentHTML("beforeend", `<option value="${value}">${label}</option>`);
+    }
+
+    return [tags, input, button, this.#list];
+  }
+
+  /* -------------------------------------------------- */
+
+  /** @inheritdoc */
+  static create(config) {
+    const { slug, value, list } = config;
+    const tags = new this({ slug, values: value, list });
+    tags.name = config.name;
+    tags.toggleAttribute("slug", !!slug);
+    tags.setAttribute("value", Array.from(value || []).join(","));
+
+    tags.setAttribute("listOptions", JSON.stringify(Array.from(list || [])));
+
+    foundry.applications.fields.setInputAttributes(tags, config);
+    return tags;
+  }
+}
+
+/* -------------------------------------------------- */
+
+/**
+ * Subclass of `SetField` that defaults to hold a `StringField` and supports rendering as an `HTMLStringTagsListElement`.
+ */
+export class ListSetField extends foundry.data.fields.SetField {
+  constructor(field, options) {
+    field ??= new foundry.data.fields.StringField();
+    super(field, options);
+  }
+
+  /* -------------------------------------------------- */
+
+  /** @inheritdoc */
+  _toInput(config) {
+    if (!config.list) return super._toInput(config);
+    return HTMLStringTagsListElement.create(config);
+  }
+}

--- a/scripts/fields.mjs
+++ b/scripts/fields.mjs
@@ -51,6 +51,45 @@ export class HTMLStringTagsListElement extends foundry.applications.elements.HTM
   /* -------------------------------------------------- */
 
   /** @inheritdoc */
+  _activateListeners() {
+    this._primaryInput.addEventListener("keydown", this.#keyDown.bind(this));
+    super._activateListeners();
+  }
+
+  /* -------------------------------------------------- */
+
+  /**
+   * Additional keyboard event listener attached prior to the super
+   * keyboard event, to make modifications to the input before submission.
+   * @param {KeyboardEvent} event
+   */
+  #keyDown(event) {
+    if (event.key !== "Enter") return;
+    event.preventDefault();
+    event.stopPropagation();
+    const input = event.currentTarget.value?.slugify();
+    if (!input) return;
+    const option = this.#listOptions.find(option => {
+      return option.value.slugify() === input;
+    });
+    if (option) event.currentTarget.value = option.value;
+  }
+
+  /* -------------------------------------------------- */
+
+  /** @inheritdoc */
+  _validateTag(tag) {
+    super._validateTag(tag);
+
+    const option = this.#listOptions.find(option => {
+      return option.value === tag;
+    });
+    if (!option) throw new Error(game.i18n.format("SYRINSCAPE.FILTERS.ERRORS.invalidValue", { value: tag }));
+  }
+
+  /* -------------------------------------------------- */
+
+  /** @inheritdoc */
   static create(config) {
     const { slug, value, list } = config;
     const tags = new this({ slug, values: value, list });

--- a/setup.mjs
+++ b/setup.mjs
@@ -7,12 +7,16 @@ import registerSyrinscapePlaylistSound from "./scripts/playlist-sound.mjs";
 import { moduleId } from "./scripts/constants.mjs";
 import * as hooks from "./scripts/hooks.mjs";
 import * as utils from "./scripts/api.mjs";
+import * as fields from "./scripts/fields.mjs";
+
+window.customElements.define(fields.HTMLStringTagsListElement.tagName, fields.HTMLStringTagsListElement);
 
 globalThis.syrinscapeControl = {
   applications: {
     SyrinscapeBrowser,
   },
   data: {
+    fields,
     SyrinscapeFilterModel,
     SyrinscapeStorage,
   },

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -112,4 +112,21 @@
   &:has(.sheet-tabs.tabs [data-tab=moods].active) [data-application-part=filters] .subtype {
     display: none;
   }
+
+  /* Custom element styling copied from string-tags core styling. */
+  string-tags-list {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 0.25rem;
+    margin: 0;
+
+    > input {
+      flex: 1;
+    }
+
+    > button.icon {
+      flex-basis: 36px;
+    }
+  }
 }

--- a/templates/browser/filters.hbs
+++ b/templates/browser/filters.hbs
@@ -1,8 +1,8 @@
 <section>
   <fieldset class="scrollable">
     {{#with filters}}
-    {{formGroup product.field value=product.value options=product.options}}
-    {{formGroup soundset.field value=soundset.value options=soundset.options}}
+    {{formGroup product.field value=product.value list=product.options}}
+    {{formGroup soundset.field value=soundset.value list=soundset.options}}
     {{formGroup subcategory.field value=subcategory.value options=subcategory.options}}
     {{formGroup status.field value=status.value options=status.options type="checkboxes"}}
     {{formGroup subtype.field value=subtype.value options=subtype.options classes="subtype" type="checkboxes"}}


### PR DESCRIPTION
Adds subclass of `HTMLStringTagsElement` and of `SetField`.

Allows for using `datalist` element.

<img width="609" height="552" alt="image" src="https://github.com/user-attachments/assets/d3b3948e-d610-49de-a624-08d97b4f1363" />

Closes #60.